### PR TITLE
Add AccountMiddleware and dependency fixes

### DIFF
--- a/intervaltimer/settings.py
+++ b/intervaltimer/settings.py
@@ -29,6 +29,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'allauth.account.middleware.AccountMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 Django==5.0.6
 djangorestframework==3.15.2
 django-allauth==0.61.1
+requests>=2.31.0,<3
+chardet==5.2.0

--- a/timers/views.py
+++ b/timers/views.py
@@ -20,7 +20,10 @@ class ClockViewSet(viewsets.ModelViewSet):
         if public == '1':
             qs = qs.filter(is_public=True)
         elif mine == '1':
-            qs = qs.filter(user=self.request.user)
+            if self.request.user.is_authenticated:
+                qs = qs.filter(user=self.request.user)
+            else:
+                qs = qs.none()
         return qs
 
     def perform_create(self, serializer):


### PR DESCRIPTION
## Summary
- add `allauth.account.middleware.AccountMiddleware` to Django MIDDLEWARE
- relax `requests` version and switch to `chardet` to avoid charset import issues
- include explicit dependencies to resolve missing charset errors

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement chardet==5.2.0; proxy 403)*
- `python manage.py check`
- `python manage.py test`
- `python manage.py makemigrations timers`


------
https://chatgpt.com/codex/tasks/task_e_68b2bf95727083288dccff446e89f1c4